### PR TITLE
fix: broken url

### DIFF
--- a/.github/dc-linkinator.config.json
+++ b/.github/dc-linkinator.config.json
@@ -14,6 +14,7 @@
         "https://apitable.com/api",
         "https://vika.cn/widget/introduction",
         "https://twitter.com/apitable_com",
-        "https://developers.apitable.com/"
+        "https://developers.apitable.com/",
+        "https://s1.vika.cn/public/2023/05/16/d2d74a23dabb4700a91594fbc975fd06%22"
     ]
 }


### PR DESCRIPTION
This url has an extra quotation mark, because of error scan